### PR TITLE
Fix autoreroll text and make speed options patch resilient

### DIFF
--- a/Brainstorm_keyhandler.lua
+++ b/Brainstorm_keyhandler.lua
@@ -32,7 +32,12 @@ function Brainstorm.key_press_update(key)
 	if key == Brainstorm.SETTINGS.keybinds.rerollSeed and love.keyboard.isDown("lctrl") then
 		FastReroll()
 	end
-	if key == Brainstorm.SETTINGS.keybinds.autoReroll and love.keyboard.isDown("lctrl") then
-		Brainstorm.AUTOREROLL.autoRerollActive = not Brainstorm.AUTOREROLL.autoRerollActive
-	end
+        if key == Brainstorm.SETTINGS.keybinds.autoReroll and love.keyboard.isDown("lctrl") then
+                Brainstorm.AUTOREROLL.autoRerollActive = not Brainstorm.AUTOREROLL.autoRerollActive
+                Brainstorm.AUTOREROLL.autoRerollFrames = 0
+                if not Brainstorm.AUTOREROLL.autoRerollActive and Brainstorm.AUTOREROLL.rerollText then
+                        Brainstorm.remove_attention_text(Brainstorm.AUTOREROLL.rerollText)
+                        Brainstorm.AUTOREROLL.rerollText = nil
+                end
+        end
 end

--- a/lovely.toml
+++ b/lovely.toml
@@ -37,7 +37,7 @@ overwrite = false
 [[patches]] #   Additional GameSpeed Options
 [patches.pattern]
 target = "functions/UI_definitions.lua"
-pattern = "create_option_cycle({label = localize('b_set_gamespeed'),scale = 0.8, options = {0.5, 1, 2, 4}, opt_callback = 'change_gamespeed', current_option = (G.SETTINGS.GAMESPEED == 0.5 and 1 or G.SETTINGS.GAMESPEED == 4 and 4 or G.SETTINGS.GAMESPEED + 1)}),"
+pattern = "create_option_cycle({label = localize('b_set_gamespeed')"
 position = "at"
 payload = '''
 create_option_cycle({label = localize('b_set_gamespeed'),scale = 0.8, options = {0.5, 1, 2, 4, 8, 16, 32}, opt_callback = 'change_gamespeed', current_option = (G.SETTINGS.GAMESPEED == 0.5 and 1 or G.SETTINGS.GAMESPEED == 4 and 4 or G.SETTINGS.GAMESPEED == 8 and 5 or G.SETTINGS.GAMESPEED == 16 and 6 or G.SETTINGS.GAMESPEED == 32 and 7 or G.SETTINGS.GAMESPEED + 1)}),


### PR DESCRIPTION
## Summary
- Reset autoreroll frame counter and remove lingering text when toggling autoreroll
- Relax gamespeed patch pattern so high speed settings can be selected again

## Testing
- `luac -p Brainstorm_keyhandler.lua Brainstorm_main.lua Brainstorm_reroll.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8c1082c832aaa85a42d8decc205